### PR TITLE
feat: add initial interface and implementation for WASI NN 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 [dependencies]
 
 [workspace]
-    members = [ "crates/cache-redis-wasmtime", "crates/http-wasmtime", "crates/log-wasmtime"]
+    members = [ "crates/cache-redis-wasmtime", "crates/http-wasmtime", "crates/log-wasmtime", "crates/nn-tract-wasmtime" ]
 
 
 [dev-dependencies]
@@ -16,7 +16,7 @@
     env_logger                  = "0.9"
     log                         = { version = "0.4", default-features = false }
     wasi-outbound-http-wasmtime = { path = "crates/http-wasmtime" }
-    log-wasmtime             = { path = "crates/log-wasmtime" }
+    log-wasmtime                = { path = "crates/log-wasmtime" }
     tokio                       = { version = "1.4.0", features = [ "full" ] }
     wasmtime                    = "0.33"
     wasmtime-wasi               = "0.33"

--- a/crates/nn-tract-wasmtime/Cargo.toml
+++ b/crates/nn-tract-wasmtime/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+    name    = "wasi-nn-tract-wasmtime"
+    version = "0.1.0"
+    edition = "2021"
+
+[lib]
+    doctest = false
+
+[dependencies]
+    anyhow               = "1.0"
+    byteorder            = "1.4"
+    log                  = "0.4"
+    ndarray              = "0.15"
+    thiserror            = "1.0"
+    tract-data           = "0.15"
+    tract-linalg         = "0.15"
+    tract-onnx           = "0.15"
+    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }

--- a/crates/nn-tract-wasmtime/src/bytes.rs
+++ b/crates/nn-tract-wasmtime/src/bytes.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Cursor;
+
+pub fn bytes_to_f32_vec(data: Vec<u8>) -> Result<Vec<f32>> {
+    let chunks: Vec<&[u8]> = data.chunks(4).collect();
+    let v: Vec<Result<f32>> = chunks
+        .into_iter()
+        .map(|c| {
+            let mut rdr = Cursor::new(c);
+            Ok(rdr.read_f32::<LittleEndian>()?)
+        })
+        .collect();
+
+    v.into_iter().collect()
+}
+
+pub fn f32_vec_to_bytes(data: Vec<f32>) -> Vec<u8> {
+    let sum: f32 = data.iter().sum();
+    log::info!(
+        "f32_vec_to_bytes: flatten output tensor contains {} elements with sum {}",
+        data.len(),
+        sum
+    );
+    let chunks: Vec<[u8; 4]> = data.into_iter().map(|f| f.to_le_bytes()).collect();
+    let result: Vec<u8> = chunks.iter().flatten().copied().collect();
+
+    log::info!(
+        "f32_vec_to_bytes: flatten byte output tensor contains {} elements",
+        result.len()
+    );
+    result
+}
+
+#[test]
+fn test_f32_bytes_array_and_back() {
+    let case = vec![0.0_f32, 1.1, 2.2, 3.3];
+    let bytes = f32_vec_to_bytes(case.clone());
+    let res = bytes_to_f32_vec(bytes).unwrap();
+    assert_eq!(case, res);
+}
+
+#[test]
+fn test_bytes_array_to_f32_array() {
+    let bytes = vec![0x00, 0x00, 0x48, 0x41, 0x00, 0x00, 0x48, 0x41];
+    let res = bytes_to_f32_vec(bytes).unwrap();
+    assert!((12.5 - res[0]).abs() < f32::EPSILON);
+    assert!((12.5 - res[1]).abs() < f32::EPSILON);
+}

--- a/crates/nn-tract-wasmtime/src/lib.rs
+++ b/crates/nn-tract-wasmtime/src/lib.rs
@@ -1,0 +1,314 @@
+// This file is an adaptation of
+// https://github.com/deislabs/wasi-nn-onnx/blob/main/crates/wasi-nn-onnx-wasmtime/src/tract.rs
+// to the new WIT format.
+
+mod bytes;
+
+use crate::{bytes::f32_vec_to_bytes, wasi_nn::TensorType};
+use bytes::bytes_to_f32_vec;
+use ndarray::Array;
+use std::{
+    collections::{btree_map::Keys, BTreeMap},
+    io::Cursor,
+    sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+use tract_onnx::{
+    prelude::Graph as TractGraph, prelude::Tensor as TractTensor, prelude::*,
+    tract_hir::infer::InferenceOp,
+};
+use wasi_nn::{ExecutionTarget, GraphBuilderArray, GraphEncoding, TensorParam, TensorResult};
+
+wit_bindgen_wasmtime::export!("wit/ephemeral/wasi-nn.wit");
+
+#[derive(Debug)]
+pub struct TractSession {
+    pub graph: TractGraph<InferenceFact, Box<dyn InferenceOp>>,
+    pub input_tensors: Option<Vec<TractTensor>>,
+    pub output_tensors: Option<Vec<Arc<TractTensor>>>,
+}
+
+impl TractSession {
+    pub fn with_graph(graph: TractGraph<InferenceFact, Box<dyn InferenceOp>>) -> Self {
+        Self {
+            graph,
+            input_tensors: None,
+            output_tensors: None,
+        }
+    }
+}
+
+/// Main context struct for which we implement the WasiNn trait.
+#[derive(Default)]
+pub struct WasiNnTractCtx {
+    pub state: Arc<RwLock<State>>,
+}
+
+// TODO (@radu-matei)
+//
+// Currently, the `State` object is only able to hold Tract ONNX related state.
+// Ideally, it could be able to hold and compute inferences for multiple implementations.
+#[derive(Default)]
+pub struct State {
+    pub executions: BTreeMap<GraphExecutionContext, TractSession>,
+    pub models: BTreeMap<Graph, Vec<u8>>,
+}
+
+impl State {
+    /// Helper function that returns the key that is supposed to be inserted next.
+    pub fn key<K: Into<u32> + From<u32> + Copy, V>(&self, keys: Keys<K, V>) -> K {
+        match keys.last() {
+            Some(&k) => {
+                let last: u32 = k.into();
+                K::from(last + 1)
+            }
+            None => K::from(0),
+        }
+    }
+}
+
+type Graph = u32;
+type GraphExecutionContext = u32;
+
+impl wasi_nn::WasiNn for WasiNnTractCtx {
+    type Graph = Graph;
+    type GraphExecutionContext = GraphExecutionContext;
+
+    fn load(
+        &mut self,
+        builder: GraphBuilderArray<'_>,
+        encoding: GraphEncoding,
+        target: ExecutionTarget,
+    ) -> Result<Self::Graph, wasi_nn::Error> {
+        log::info!("load: encoding: {:?}, target: {:?}", encoding, target);
+        if encoding != GraphEncoding::Onnx {
+            log::error!("load current implementation can only load ONNX models");
+            return Err(wasi_nn::Error::InvalidEncoding);
+        }
+
+        let model_bytes = builder[0];
+        let mut state = self.state.write()?;
+        let graph = state.key(state.models.keys());
+        log::info!(
+            "load: inserting graph: {:#?} with size {:#?}",
+            graph,
+            model_bytes.len()
+        );
+        state.models.insert(graph, model_bytes.to_vec());
+        log::info!("load: current number of models: {:#?}", state.models.len());
+        Ok(graph)
+    }
+
+    fn init_execution_context(
+        &mut self,
+        graph: &Self::Graph,
+    ) -> Result<Self::GraphExecutionContext, wasi_nn::Error> {
+        log::info!("init_execution_context: graph: {:#?}", graph);
+        let mut state = self.state.write()?;
+        let mut model_bytes = match state.models.get(&graph) {
+            Some(mb) => Cursor::new(mb),
+            None => {
+                log::error!(
+                    "init_execution_context: cannot find model in state with graph {:#?}",
+                    graph
+                );
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+        };
+
+        let model = tract_onnx::onnx().model_for_read(&mut model_bytes).unwrap();
+
+        let gec = state.key(state.executions.keys());
+        log::info!(
+            "init_execution_context: inserting graph execution context: {:#?}",
+            gec
+        );
+
+        state
+            .executions
+            .insert(gec, TractSession::with_graph(model));
+
+        Ok(gec)
+    }
+
+    fn set_input(
+        &mut self,
+        ctx: &Self::GraphExecutionContext,
+        index: u32,
+        tensor: TensorParam<'_>,
+    ) -> Result<(), wasi_nn::Error> {
+        let mut state = self.state.write()?;
+        let execution = match state.executions.get_mut(&ctx) {
+            Some(s) => s,
+            None => {
+                log::error!(
+                    "set_input: cannot find session in state with context {:#?}",
+                    ctx
+                );
+
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+        };
+
+        let shape = tensor
+            .dimensions
+            .iter()
+            .map(|d| d.get() as usize)
+            .collect::<Vec<_>>();
+
+        execution.graph.set_input_fact(
+            index as usize,
+            InferenceFact::dt_shape(f32::datum_type(), shape.clone()),
+        )?;
+
+        let data = bytes_to_f32_vec(tensor.data.to_vec())?;
+        let input: TractTensor = Array::from_shape_vec(shape, data)?.into();
+
+        match execution.input_tensors {
+            Some(ref mut input_arrays) => {
+                input_arrays.push(input);
+                log::info!(
+                    "set_input: input arrays now contains {} items",
+                    input_arrays.len(),
+                );
+            }
+            None => {
+                execution.input_tensors = Some(vec![input]);
+            }
+        };
+
+        Ok(())
+    }
+
+    fn compute(&mut self, ctx: &Self::GraphExecutionContext) -> Result<(), wasi_nn::Error> {
+        let mut state = self.state.write()?;
+        let mut execution = match state.executions.get_mut(&ctx) {
+            Some(s) => s,
+            None => {
+                log::error!(
+                    "compute: cannot find session in state with context {:#?}",
+                    ctx
+                );
+
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+        };
+        // TODO
+        //
+        // There are two `.clone()` calls here that could prove
+        // to be *very* inneficient, one in getting the input tensors,
+        // the other in making the model runnable.
+        let input_tensors: Vec<TractTensor> = execution
+            .input_tensors
+            .as_ref()
+            .unwrap_or(&vec![])
+            .clone()
+            .into_iter()
+            .collect();
+
+        log::info!(
+            "compute: input tensors contains {} elements",
+            input_tensors.len()
+        );
+
+        // Some ONNX models don't specify their input tensor
+        // shapes completely, so we can only call `.into_optimized()` after we
+        // have set the input tensor shapes.
+        let output_tensors = execution
+            .graph
+            .clone()
+            .into_optimized()?
+            .into_runnable()?
+            .run(input_tensors.into())?;
+
+        log::info!(
+            "compute: output tensors contains {} elements",
+            output_tensors.len()
+        );
+
+        match execution.output_tensors {
+            Some(_) => {
+                log::error!("compute: existing data in output_tensors, aborting");
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+            None => {
+                execution.output_tensors = Some(output_tensors.into_iter().collect());
+            }
+        };
+
+        Ok(())
+    }
+
+    fn get_output(
+        &mut self,
+        ctx: &Self::GraphExecutionContext,
+        index: u32,
+    ) -> Result<TensorResult, wasi_nn::Error> {
+        let state = self.state.read()?;
+        let execution = match state.executions.get(&ctx) {
+            Some(s) => s,
+            None => {
+                log::error!(
+                    "compute: cannot find session in state with context {:#?}",
+                    ctx
+                );
+
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+        };
+
+        let output_tensors = match execution.output_tensors {
+            Some(ref oa) => oa,
+            None => {
+                log::error!("get_output: output_tensors for session is none. Perhaps you haven't called compute yet?");
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+        };
+
+        let tensor = match output_tensors.get(index as usize) {
+            Some(a) => a,
+            None => {
+                log::error!(
+                    "get_output: output_tensors does not contain index {}",
+                    index
+                );
+                return Err(wasi_nn::Error::RuntimeError);
+            }
+        };
+
+        let dimensions: Vec<_> = tensor.shape().iter().map(|s| *s as u32).collect();
+        let tensor_type = TensorType::Fp32;
+        let data = f32_vec_to_bytes(tensor.as_slice().unwrap().to_vec());
+
+        let res = TensorResult {
+            dimensions,
+            tensor_type,
+            data,
+        };
+
+        Ok(res)
+    }
+}
+
+impl From<PoisonError<RwLockWriteGuard<'_, State>>> for wasi_nn::Error {
+    fn from(_: PoisonError<RwLockWriteGuard<'_, State>>) -> Self {
+        Self::RuntimeError
+    }
+}
+
+impl From<PoisonError<RwLockReadGuard<'_, State>>> for wasi_nn::Error {
+    fn from(_: PoisonError<RwLockReadGuard<'_, State>>) -> Self {
+        Self::RuntimeError
+    }
+}
+
+impl From<anyhow::Error> for wasi_nn::Error {
+    fn from(_: anyhow::Error) -> Self {
+        Self::RuntimeError
+    }
+}
+
+impl From<tract_ndarray::ShapeError> for wasi_nn::Error {
+    fn from(_: tract_ndarray::ShapeError) -> Self {
+        Self::RuntimeError
+    }
+}

--- a/wit/ephemeral/wasi-nn.wit
+++ b/wit/ephemeral/wasi-nn.wit
@@ -1,0 +1,98 @@
+// WASI Machine Learning API
+// Adapted from https://github.com/WebAssembly/wasi-nn
+//
+// This module draws inspiration from the inference side of [WebNN](https://webmachinelearning.github.io/webnn/#api).
+// In other words, this API will allow a user to execute an inference using an execution graph (i.e. a model), but not
+// train or design the graph. The graph is an opaque byte sequence to this API and must be interpreted by the underlying
+// implementation of this API.
+
+// Error codes returned by functions in this API.
+enum error {
+    // No error occurred.
+    success,
+    // Caller module passed an invalid argument.
+    invalid-argument,
+    // Invalid encocing.
+    invalid-encoding,
+    // Caller module is missing a memory export.
+    missing-memory,
+    // Device or resource busy.
+    busy,
+    // Runtime Error.
+    runtime-error,
+}
+
+// The dimensions of a tensor.
+//
+// The array length matches the tensor rank and each element in the array 
+// describes the size of each dimension.
+type tensor-dimensions = list<u32>
+
+// The type of the elements in a tensor.
+enum tensor-type {
+    fp16,
+    fp32,
+    up8,
+    ip32
+}
+
+// The tensor data.
+//
+// Initially coneived as a sparse representation, each empty cell would be filled with zeros and 
+// the array length must match the product of all of the dimensions and the number of bytes in the type (e.g. a 2x2
+// tensor with 4-byte f32 elements would have a data array of length 16). Naturally, this representation requires
+// some knowledge of how to lay out data in memory--e.g. using row-major ordering--and could perhaps be improved. 
+type tensor-data = list<u8>
+
+// A tensor.
+record tensor {
+    // Describe the size of the tensor (e.g. 2x2x2x2 -> [2, 2, 2, 2]). To represent a tensor containing a single value,
+    // use `[1]` for the tensor dimensions. 
+    dimensions: tensor-dimensions,
+
+    // Describe the type of element in the tensor (e.g. f32).
+    tensor-type: tensor-type,
+    
+    // Contains the tensor data.
+    data: tensor-data,
+}
+
+// The graph initialization data. This consists of an array of buffers because implementing backends may encode their
+// graph IR in parts (e.g. OpenVINO stores its IR and weights separately).
+type graph-builder = list<u8>
+type graph-builder-array = list<graph-builder>
+
+// An execution graph for performing inference (i.e. a model).
+resource graph
+
+// Describes the encoding of the graph. This allows the API to be implemented by various backends that encode (i.e.
+// serialize) their graph IR differently.
+enum graph-encoding {
+    openvino,
+    onnx,
+    tensorflow
+}
+
+// Define where the graph should be executed.
+enum execution-target {
+    cpu,
+    gpu,
+    tpu
+}
+
+resource graph-execution-context
+
+// Load an opaque sequence of bytes to use for inference.
+load: function(builder: graph-builder-array, encoding: graph-encoding, target: execution-target) -> expected<graph, error>
+
+// Create an execution instance of a loaded graph.
+init-execution-context: function(graph: graph) -> expected<graph-execution-context, error>
+
+// Define inputs to use for inference.
+set-input: function(ctx: graph-execution-context, index: u32, tensor: tensor) -> expected<_, error>
+
+// Compute the inference on the given inputs.
+compute: function(ctx: graph-execution-context) -> expected<_, error>
+
+// Extract the outputs after inference.
+get-output: function(ctx: graph-execution-context, index: u32) -> expected<tensor, error>


### PR DESCRIPTION
This commit begins the adaptation of the WASI NN interface to the new
WIT format, and adds a WIP implementation for the API using the Tract
ONNX implementation as the only inferencing engine (ideally, the same
implementation would also allow the execution of Tensorflow graphs,
potentially using the same Tract implementation).

This is currently a WIP, as there are no tests yet.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>