### PR TITLE
chore: update Wasmtime to v0.33.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@
     log                         = { version = "0.4", default-features = false }
     wasi-outbound-http-wasmtime = { path = "crates/http-wasmtime" }
     tokio                       = { version = "1.4.0", features = [ "full" ] }
-    wasmtime                    = "0.32"
-    wasmtime-wasi               = "0.32"
-    wasi-common                 = "0.32"
-    wasi-cap-std-sync           = "0.32"
-    wit-bindgen-wasmtime        = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wasmtime                    = "0.33"
+    wasmtime-wasi               = "0.33"
+    wasi-common                 = "0.33"
+    wasi-cap-std-sync           = "0.33"
+    wit-bindgen-wasmtime        = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 const WIT_BINDGEN_REPO: &str = "https://github.com/bytecodealliance/wit-bindgen";
-const WIT_BINDGEN_REVISION: &str = "dab589f579b980c81b39c8348400b88a8c4d175a";
+const WIT_BINDGEN_REVISION: &str = "2e654dc82b7f9331719ba617a36ed5967b2aecb0";
 
 const WIT_DIRECTORY: &str = "wit/ephemeral/*";
 

--- a/crates/cache-azure-blobstorage/Cargo.toml
+++ b/crates/cache-azure-blobstorage/Cargo.toml
@@ -13,7 +13,7 @@
     azure_storage    = { git = "https://github.com/radu-matei/azure-sdk-for-rust", branch = "enable-wasi-experimental-http" }
     bytes            = "1"
     futures          = "0.3"
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }
 
 # The patches below currently require this to be a separate workspace.
 [workspace]

--- a/crates/cache-fs/Cargo.toml
+++ b/crates/cache-fs/Cargo.toml
@@ -9,6 +9,6 @@
 
 [dependencies]
     anyhow           = "1.0"
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }
 
 [workspace]

--- a/crates/cache-redis-wasmtime/Cargo.toml
+++ b/crates/cache-redis-wasmtime/Cargo.toml
@@ -13,4 +13,4 @@
     log                  = { version = "0.4", default-features = false }
     redis                = { version = "0.21", features = [ "tokio-comp" ] }
     tokio                = { version = "1.14", features = [ "full" ] }
-    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }

--- a/crates/http-wasmtime/Cargo.toml
+++ b/crates/http-wasmtime/Cargo.toml
@@ -15,4 +15,4 @@
     reqwest              = { version = "0.11", default-features = true, features = [ "json", "blocking" ] }
     tokio                = { version = "1.4.0", features = [ "full" ] }
     url                  = "2.2.1"
-    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }

--- a/tests/modules/cache-rust/Cargo.toml
+++ b/tests/modules/cache-rust/Cargo.toml
@@ -8,6 +8,6 @@
     crate-type = [ "cdylib" ]
 
 [dependencies]
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }
 
 [workspace]

--- a/tests/modules/http-rust-hello/Cargo.toml
+++ b/tests/modules/http-rust-hello/Cargo.toml
@@ -8,6 +8,6 @@
     crate-type = [ "cdylib" ]
 
 [dependencies]
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dab589f579b980c81b39c8348400b88a8c4d175a" }
+    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "2e654dc82b7f9331719ba617a36ed5967b2aecb0" }
 
 [workspace]

--- a/tests/modules/http-rust-hello/src/lib.rs
+++ b/tests/modules/http-rust-hello/src/lib.rs
@@ -22,7 +22,7 @@ impl test::Test for Test {
         println!("Body: {}", body);
 
         assert_eq!(200, res.status);
-        assert_eq!("\"OK\"", body);
+        assert_eq!("", body);
 
         Ok(())
     }


### PR DESCRIPTION
This commit updates Wasmtime to v0.33.0.
Additionally, it also fixes the expected response body from the HTTP
test.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>