### PR TITLE
Test fixes for external C++/Redis tests

### DIFF
--- a/tests/modules/cache-cpp/Makefile
+++ b/tests/modules/cache-cpp/Makefile
@@ -7,9 +7,9 @@ bindgen:
 	$(WIT_BINDGEN) c --export ../../test.wit --out-dir bindings
 	
 build:
-	$(WASI_CC) -I . -I ./bindings -c -o wasi_cache.o bindings/wasi-cache.c
-	$(WASI_CC) -I . -I ./bindings -c -o test.o bindings/test.c
-	$(WASI_CC) -mexec-model=reactor lib.cpp wasi_cache.o test.o -o ctest.wasm
+	$(WASI_CC) -Wall -I . -I ./bindings -c -o wasi_cache.o bindings/wasi-cache.c
+	$(WASI_CC) -Wall -I . -I ./bindings -c -o test.o bindings/test.c
+	$(WASI_CC) -Wall -mexec-model=reactor lib.cpp wasi_cache.o test.o -o ctest.wasm
 
 
 link: link-fs


### PR DESCRIPTION
The way that `exec_core` was written, the C++ & Redis tests couldn’t actually fail even if they returned failure codes. It handles a `Result<Result<_,_>>` but only one layer of `Result` was unwrapped. If the inner `Result` was a test failure the test would still succeed.

Also fixup and improve the C++ code so it checks all results, add `-Wall` flag to build step. While doing this I noticed that the C bindings return an expected error code upon success…